### PR TITLE
Fix CreateAssistantFileRequest json serialization

### DIFF
--- a/client.go
+++ b/client.go
@@ -2673,7 +2673,7 @@ type CreateAssistantFileRequest struct {
 	// https://platform.openai.com/docs/api-reference/assistants/createAssistantFile#assistants-createassistantfile-file
 	//
 	// Required.
-	FileID string `json:"file"`
+	FileID string `json:"file_id"`
 }
 
 // https://platform.openai.com/docs/api-reference/assistants/createAssistantFile#assistants-createassistantfile-response


### PR DESCRIPTION
The documentation for the CreateAssistantFile endpoint explicitly requires a "file_id" field, and not a "file" field, which it was previously. 

This simple change fixes the issue so that CreateAssistantFile does not invariably produce a Bad Request response.